### PR TITLE
Add the HX-Boosted and other missing headers

### DIFF
--- a/src/Servant/Htmx.hs
+++ b/src/Servant/Htmx.hs
@@ -78,3 +78,9 @@ type HXTriggerAfterSwap = Header "HX-Trigger-After-Swap" Text
 type HXTriggerAfterSettle = Header "HX-Trigger-After-Settle" Text
 
 type HXBoosted = Header "HX-Boosted" Text
+
+type HXCurrentURL = Header "HX-Current-URL" Text
+
+type HXHistoryRestoreRequest = Header "HX-History-Restore-Request" Text
+
+type HXRetarget = Header "HX-Retarget" Text

--- a/src/Servant/Htmx.hs
+++ b/src/Servant/Htmx.hs
@@ -76,3 +76,5 @@ type HXTrigger = Header "HX-Trigger" Text
 type HXTriggerAfterSwap = Header "HX-Trigger-After-Swap" Text
 
 type HXTriggerAfterSettle = Header "HX-Trigger-After-Settle" Text
+
+type HXBoosted = Header "HX-Boosted" Text

--- a/src/Servant/Htmx.hs
+++ b/src/Servant/Htmx.hs
@@ -49,6 +49,10 @@ module Servant.Htmx
     HXTrigger,
     HXTriggerAfterSwap,
     HXTriggerAfterSettle,
+    HXBoosted,
+    HXCurrentURL,
+    HXHistoryRestoreRequest,
+    HXRetarget,
   )
 where
 


### PR DESCRIPTION
This PR introduces the HX-Boosted header, which indicates when a request was boosted
https://htmx.org/reference/